### PR TITLE
tests passing on 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.12

--- a/lib/AudioBuffer.js
+++ b/lib/AudioBuffer.js
@@ -19,9 +19,9 @@ class AudioBuffer {
   }
 
   slice() {
-    var sliceArgs = _.toArray(arguments),
-      array = this._data.map(function(chArray) {
-        return chArray.slice.apply(chArray, sliceArgs)
+    var sliceArgs = _.toArray(arguments)
+    var array = this._data.map(function(chArray) {
+        return chArray.subarray.apply(chArray, sliceArgs)
       })
     return AudioBuffer.fromArray(array, this.sampleRate)
   }

--- a/test/AudioBuffer-test.js
+++ b/test/AudioBuffer-test.js
@@ -102,7 +102,6 @@ describe('AudioBuffer', function() {
   })
 
   describe('slice', function() {
-
     it('should slice properly all channels', function() {
       var sliced
         , ab = AudioBuffer.fromArray([

--- a/test/AudioBufferSourceNode-test.js
+++ b/test/AudioBufferSourceNode-test.js
@@ -74,7 +74,7 @@ describe('AudioBufferSourceNode', function() {
       helpers.assertAllValuesEqual(blocks[0].getChannelData(0), 0)
 
       // Full blocks read
-      blocks.subarray(1, 4).forEach(function(audioBuffer, i) {
+      blocks.slice(1, 4).forEach(function(audioBuffer, i) {
         assert.equal(audioBuffer.numberOfChannels, 2)
         assert.equal(audioBuffer.length, 128)
       })

--- a/test/AudioBufferSourceNode-test.js
+++ b/test/AudioBufferSourceNode-test.js
@@ -74,7 +74,7 @@ describe('AudioBufferSourceNode', function() {
       helpers.assertAllValuesEqual(blocks[0].getChannelData(0), 0)
 
       // Full blocks read
-      blocks.slice(1, 4).forEach(function(audioBuffer, i) {
+      blocks.subarray(1, 4).forEach(function(audioBuffer, i) {
         assert.equal(audioBuffer.numberOfChannels, 2)
         assert.equal(audioBuffer.length, 128)
       })
@@ -90,10 +90,10 @@ describe('AudioBufferSourceNode', function() {
       // Incomplete block read
       assert.equal(blocks[5].numberOfChannels, 2)
       assert.equal(blocks[5].length, 128)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).slice(0, 63), 0.5)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).slice(64, 128), 0)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).slice(0, 63), -0.5)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).slice(64, 128), 0)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).subarray(0, 63), 0.5)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).subarray(64, 128), 0)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).subarray(0, 63), -0.5)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).subarray(64, 128), 0)
 
       // Playback over
       assert.throws(function() { node._tick() })
@@ -128,20 +128,20 @@ describe('AudioBufferSourceNode', function() {
       helpers.assertAllValuesApprox(blocks[3].getChannelData(1), -0.4)
 
       // Incomplete blocks read
-      helpers.assertAllValuesApprox(blocks[4].getChannelData(0).slice(0, 63), 0.5)
-      helpers.assertAllValuesApprox(blocks[4].getChannelData(1).slice(0, 63), -0.5)
-      helpers.assertAllValuesApprox(blocks[4].getChannelData(0).slice(64, 128), 0.1)
-      helpers.assertAllValuesApprox(blocks[4].getChannelData(1).slice(64, 128), -0.1)
+      helpers.assertAllValuesApprox(blocks[4].getChannelData(0).subarray(0, 63), 0.5)
+      helpers.assertAllValuesApprox(blocks[4].getChannelData(1).subarray(0, 63), -0.5)
+      helpers.assertAllValuesApprox(blocks[4].getChannelData(0).subarray(64, 128), 0.1)
+      helpers.assertAllValuesApprox(blocks[4].getChannelData(1).subarray(64, 128), -0.1)
 
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).slice(0, 63), 0.1)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).slice(0, 63), -0.1)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).slice(64, 128), 0.2)
-      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).slice(64, 128), -0.2)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).subarray(0, 63), 0.1)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).subarray(0, 63), -0.1)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(0).subarray(64, 128), 0.2)
+      helpers.assertAllValuesApprox(blocks[5].getChannelData(1).subarray(64, 128), -0.2)
 
-      helpers.assertAllValuesApprox(blocks[6].getChannelData(0).slice(0, 63), 0.2)
-      helpers.assertAllValuesApprox(blocks[6].getChannelData(1).slice(0, 63), -0.2)
-      helpers.assertAllValuesApprox(blocks[6].getChannelData(0).slice(64, 128), 0.3)
-      helpers.assertAllValuesApprox(blocks[6].getChannelData(1).slice(64, 128), -0.3)
+      helpers.assertAllValuesApprox(blocks[6].getChannelData(0).subarray(0, 63), 0.2)
+      helpers.assertAllValuesApprox(blocks[6].getChannelData(1).subarray(0, 63), -0.2)
+      helpers.assertAllValuesApprox(blocks[6].getChannelData(0).subarray(64, 128), 0.3)
+      helpers.assertAllValuesApprox(blocks[6].getChannelData(1).subarray(64, 128), -0.3)
     })
 
     it('should loop the audio from offset to offset + duration', function() {
@@ -166,20 +166,20 @@ describe('AudioBufferSourceNode', function() {
 
       // The loop is 1.5 blocks, so the offset loop/block resolves every 3 blocks
       for (var i = 0; i < 3; i++) {
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).slice(0, 63), 0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).slice(0, 63), -0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).slice(64, 128), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).slice(64, 128), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).subarray(0, 63), 0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).subarray(0, 63), -0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).subarray(64, 128), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).subarray(64, 128), -0.2)
 
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).slice(0, 63), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).slice(0, 63), -0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).slice(64, 128), 0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).slice(64, 128), -0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).subarray(0, 63), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).subarray(0, 63), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).subarray(64, 128), 0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).subarray(64, 128), -0.1)
 
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).slice(0, 63), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).slice(0, 63), -0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).slice(64, 128), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).slice(64, 128), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).subarray(0, 63), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).subarray(0, 63), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).subarray(64, 128), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).subarray(64, 128), -0.2)
       }
     })
 
@@ -207,20 +207,20 @@ describe('AudioBufferSourceNode', function() {
 
       // The loop is 1.5 blocks, so the offset loop/block resolves every 3 blocks
       for (var i = 0; i < 3; i++) {
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).slice(0, 63), 0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).slice(0, 63), -0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).slice(64, 128), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).slice(64, 128), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).subarray(0, 63), 0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).subarray(0, 63), -0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(0).subarray(64, 128), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 0].getChannelData(1).subarray(64, 128), -0.2)
 
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).slice(0, 63), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).slice(0, 63), -0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).slice(64, 128), 0.1)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).slice(64, 128), -0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).subarray(0, 63), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).subarray(0, 63), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(0).subarray(64, 128), 0.1)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 1].getChannelData(1).subarray(64, 128), -0.1)
 
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).slice(0, 63), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).slice(0, 63), -0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).slice(64, 128), 0.2)
-        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).slice(64, 128), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).subarray(0, 63), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).subarray(0, 63), -0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(0).subarray(64, 128), 0.2)
+        helpers.assertAllValuesApprox(blocks[i * 3 + 2].getChannelData(1).subarray(64, 128), -0.2)
       }
     })
 


### PR DESCRIPTION
Fixes #34

The reason tests weren't passing in 0.12 is because in 0.11.4 node switched to using v8 native `TypedArray`s, which seem not to support `slice`, and use `subarray` instead. The fix involved refactoring one actual lib file, AudioBuffer.js to use `subarray` rather than `slice` in its own `slice` method, and when tests deal directly with `Float32Array` objects, call `subarray` rather than `slice`. If I understand correctly, `subarray` is faster than `slice` anyway, so this shouldn't be a problem.

Tests now pass 100% in 0.12 and 0.10. I would be happy to run them against any other version of node you like.