### PR TITLE
Fix README.md / dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,24 @@
+sudo: false
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+      - libasound2-dev
+
 language: node_js
+
 node_js:
   - 0.10
   - 0.12
+
+install:
+  - PATH="`npm bin`:`npm bin -g`:$PATH"
+  # Node 0.8 comes with a too obsolete npm
+  - if [[ "`node --version`" =~ ^v0\.8\. ]]; then npm install -g npm@1.4.28 ; fi
+  # Install dependencies and build
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,4 @@
-sudo: false
-
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-      - libasound2-dev
-
 language: node_js
-
 node_js:
   - 0.10
   - 0.12
-
-install:
-  - PATH="`npm bin`:`npm bin -g`:$PATH"
-  # Node 0.8 comes with a too obsolete npm
-  - if [[ "`node --version`" =~ ^v0\.8\. ]]; then npm install -g npm@1.4.28 ; fi
-  # Install dependencies and build
-  - npm install

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Each time you create an ```AudioNode``` (like for instance an ```AudioBufferSour
 - register schedule events with ```_schedule```
 - compute the appropriate digital signal processing with ```_tick```
 
-Each time you connect an ```AudioNode``` using ```source.connect(destination, output, input)``` it connects the relevant ```AudioOutput``` instances of ```source``` node the the relevant ```AudioInput``` instance of the ```destination``` node.
+Each time you connect an ```AudioNode``` using ```source.connect(destination, output, input)``` it connects the relevant ```AudioOutput``` instances of ```source``` node to the relevant ```AudioInput``` instance of the ```destination``` node.
 
 To instantiate all of these ```AudioNode```, you needed an overall ```AudioContext``` instance. This latter has a ```destination``` property (where the sound will flow out), instance of ```AudioDestinationNode```, which inherits from ```AudioNode```. The ```AudioContext``` instance keeps track of connections to the ```destination```. When that happens, it triggers the audio loop, calling ```_tick``` infinitely on the ```destination```, which will itself call ```_tick``` on its input ... and so forth go up on the whole audio graph.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Get ready, this is going to blow up your mind :
 
 ```
 npm install
-gulp default
-node test/manual-testing/AudioContext-sound-output.js
+npm run test-manual
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Get ready, this is going to blow up your mind :
 
 ```
 npm install
-npm run test-manual
+npm run test-speaker
 ```
 
 
@@ -153,7 +153,7 @@ Manual testing
 You can test the sound output using `node-speaker`.
 
 ```
-npm run test-manual
+npm run test-speaker
 ```
 
 To test `AudioParam` against `AudioParam` implemented in a browser, open `test/manual-testing/AudioParam-browser-plots.html` in that browser.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A live example is available on [Sébastien's website](http://funktion.fm/#/proje
 Using Gibber
 ---------------
 
-[Gibber](https://github.com/charlieroberts/Gibber) is a great audiovisual live coding environment for the browser made by [Charlie Roberts](http://charlie-roberts.com). For audio, it uses Web Audio API, so you can run it on **node-web-audio-api**. First install gibber with npm : 
+[Gibber](https://github.com/charlieroberts/Gibber) is a great audiovisual live coding environment for the browser made by [Charlie Roberts](http://charlie-roberts.com). For audio, it uses Web Audio API, so you can run it on **node-web-audio-api**. First install gibber with npm :
 
 `npm install gibber.audio.lib`
 
@@ -141,13 +141,7 @@ that way the audio loop is stopped, and you can inspect your objects in peace.
 Running the tests
 ------------------
 
-Tests are written with mocha. To run them, install mocha with :
-
-```
-npm install -g mocha
-```
-
-And in the root folder run :
+Tests are written with mocha.
 
 ```
 npm test

--- a/README.md
+++ b/README.md
@@ -151,13 +151,10 @@ npm test
 Manual testing
 ----------------
 
-To test the sound output, we need to install `node-speaker` (in addition of all the other dependencies), and build the library :
+You can test the sound output using `node-speaker`.
 
 ```
-npm install
-npm install speaker
-gulp default
-node test/manual-testing/AudioContext-sound-output.js
+npm run test-manual
 ```
 
 To test `AudioParam` against `AudioParam` implemented in a browser, open `test/manual-testing/AudioParam-browser-plots.html` in that browser.

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   "devDependencies": {
     "chai": "1.7.x",
     "gulp": "3.8.x",
-    "gulp-util": "3.0.x",
-    "gulp-es6-transpiler": "1.0.x",
     "gulp-contribs": "0.0.x",
-    "mocha": "*"
+    "gulp-es6-transpiler": "1.0.x",
+    "gulp-util": "3.0.x",
+    "mocha": "*",
+    "speaker": "^0.2.6"
   },
   "license": "MIT",
   "engines": {
@@ -42,6 +43,7 @@
   "scripts": {
     "pretest": "gulp",
     "test": "mocha",
+    "test-manual": "node test/manual-testing/AudioContext-sound-output.js",
     "prepublish": "gulp"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pretest": "gulp",
     "test": "mocha",
     "test-manual": "node test/manual-testing/AudioContext-sound-output.js",
-    "prepublish": "gulp"
+    "prepublish": "gulp",
+    "postinstall": "gulp"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "pretest": "gulp",
     "test": "mocha",
-    "test-manual": "node test/manual-testing/AudioContext-sound-output.js",
+    "test-speaker": "node test/manual-testing/AudioContext-sound-output.js",
     "prepublish": "gulp",
     "postinstall": "gulp"
   }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "gulp-contribs": "0.0.x",
     "gulp-es6-transpiler": "1.0.x",
     "gulp-util": "3.0.x",
-    "mocha": "*",
-    "speaker": "^0.2.6"
+    "mocha": "*"
   },
   "license": "MIT",
   "engines": {
@@ -44,6 +43,7 @@
     "pretest": "gulp",
     "test": "mocha",
     "test-speaker": "node test/manual-testing/AudioContext-sound-output.js",
+    "pretest-speaker": "npm install speaker",
     "prepublish": "gulp",
     "postinstall": "gulp"
   }


### PR DESCRIPTION
This P-R includes 3 changes:

- Remove `npm install -g mocha` from README.md.
  When we run `npm test`, npm will find `node_modules/.bin/mocha` and run it automatically.

- Add `speaker` to devDependencies and add `npm run test-speaker` script.
  `devDependencies` won't be installed when `node-web-audio-api` itself is installed from other repositories.
  So we don't have to worry about the size, or time. 

- Run `gulp` (≒ `gulp default`) on `postinstall`.
  DEMO is now more simple.