### PR TITLE
Use gulp-babel instead of gulp-es6-transpiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 var gulp = require('gulp')
   , gutil = require('gulp-util')
   , contribs = require('gulp-contribs')
-  , es6transpiler = require('gulp-es6-transpiler')
+  , babel = require('gulp-babel')
 
 gulp.task('default', function () {
     return gulp.src('lib/*.js')
-      .pipe(es6transpiler({ disallowDuplicated: false }))
+      .pipe(babel({ presets: ['es2015'] }))
       .on('error', gutil.log)
       .pipe(gulp.dest('build'))
 })

--- a/lib/AudioContext.js
+++ b/lib/AudioContext.js
@@ -15,6 +15,8 @@ var _ = require('underscore')
 class AudioContext extends events.EventEmitter {
 
   constructor(opts) {
+    super();
+
     var outBuff
 
     /*Object.defineProperty(this, 'currentTime', {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
   },
   "analyze": false,
   "devDependencies": {
+    "babel-preset-es2015": "^6.5.0",
     "chai": "1.7.x",
     "gulp": "3.8.x",
-    "gulp-util": "3.0.x",
-    "gulp-es6-transpiler": "1.0.x",
+    "gulp-babel": "^6.1.2",
     "gulp-contribs": "0.0.x",
+    "gulp-util": "3.0.x",
     "mocha": "*"
   },
   "license": "MIT",


### PR DESCRIPTION
This P-R contains 2 changes:

- Install `gulp-babel` `babel-preset-es2015` and use then in gulpfile.js
- Uninstall `gulp-es6-transpiler`